### PR TITLE
llvm submodule using ssh instead of https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/llvm-project"]
 	path = 3rdparty/llvm-project
-	url = git@github.com:llvm/llvm-project
+	url = https://github.com/llvm/llvm-project


### PR DESCRIPTION
I'm trying to install lambdasoc in a docker image and I noticed that the llvm submodule was added using ssh protocol.

This PR changes the SSH protocol to HTTPS in order to be able to install lambdasoc without sshkeys.

```
root@3d641be4a5f9:/# pip3 install git+https://github.com/lambdaconcept/lambdasoc-bios
Collecting git+https://github.com/lambdaconcept/lambdasoc-bios
  Cloning https://github.com/lambdaconcept/lambdasoc-bios to /tmp/pip-req-build-gl_oqsww
The authenticity of host 'github.com (140.82.112.4)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.112.4' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:llvm/llvm-project' into submodule path '/tmp/pip-req-build-gl_oqsww/3rdparty/llvm-project' failed
Failed to clone '3rdparty/llvm-project'. Retry scheduled
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Regards