### PR TITLE
No llvm submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 *.d
 *.elf
 *.bin
+3rdparty
+*.tar.gz

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/llvm-project"]
-	path = 3rdparty/llvm-project
-	url = git@github.com:llvm/llvm-project

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -34,6 +34,13 @@ endif
 
 $(crt-obj)/%.o: CPPFLAGS = $(CPPFLAGS_crt)
 
+main.tar.gz:
+	wget https://github.com/llvm/llvm-project/archive/main.tar.gz
+
+$(crt-src)/%.c: main.tar.gz
+	mkdir -p $(top)/3rdparty/llvm-project
+	tar xf main.tar.gz --strip-components=1 -C $(top)/3rdparty/llvm-project
+
 $(crt-obj)/%.o: $(crt-src)/%.c
 	$(COMPILE.c) -o $@ $<
 


### PR DESCRIPTION
The llvm repository is downloaded just if it is needed during the building process and It is downloaded as tar.gz instead of git reducing the installation time from several minutes to just a few seconds. 

Resolves https://github.com/lambdaconcept/lambdasoc/issues/12